### PR TITLE
Update workflow to publish public package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,6 @@ jobs:
       - name: Install dependencies
         run: yarn
       - name: Publish package
-        run: yarn publish
+        run: yarn publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Scoped packages are private by default. I updated the workflow command to publish the package as a public one.