### PR TITLE
Added proxy config to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,11 @@ Yeoman based generator for Symphony Bots and Applications:
 - [WDK (Symphony Workflow Developer Kit)](https://github.com/finos/symphony-wdk)
 
 ## Installation
-Install Yeoman command line utility
+Install the Yeoman utility and Symphony Generator
 ```shell
-npm i -g yo
+npm install -g yo @finos/generator-symphony
 ```
-Install Symphony Generator
-```shell
-npm i -g @finos/generator-symphony
-```
+
 ## Usage
 ![](./docs/gifs/demo.gif)
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Build](https://github.com/finos/symphony-bdk-java/actions/workflows/build.yml/badge.svg)](https://github.com/finos/symphony-bdk-java/actions/workflows/build.yml)
 
 # Symphony Generator
-
 Yeoman based generator for Symphony Bots and Applications:
 - [Java bot](https://github.com/finos/symphony-bdk-java)
 - [Python bot](https://github.com/finos/symphony-bdk-python)
@@ -12,13 +11,13 @@ Yeoman based generator for Symphony Bots and Applications:
 ## Installation
 Install Yeoman command line utility
 ```shell
-npm install -g yo
+npm i -g yo
 ```
 Install Symphony Generator
 ```shell
 npm i -g @finos/generator-symphony
 ```
-## Usage example
+## Usage
 ![](./docs/gifs/demo.gif)
 
 Create a new directory and go into it
@@ -29,7 +28,10 @@ Run Symphony Generator and follow instructions on screen
 ```shell
 yo @finos/symphony
 ```
-
+If you are behind a web proxy, use the `https_proxy` environment variable to configure the address of your proxy server and port.
+```shell
+export https_proxy=http://localhost:3128
+```
 
 ## Known issues
 


### PR DESCRIPTION
### Description
The readme docs do not describe how to use the generator when behind a proxy. Since #155, the generator does a fetch to maven to check the latest BDK version, which fails when the user does not have a direct Internet connection. This can be addressed by adding a `https_proxy` environment variable, which needs to be described in the readme.