### PR TITLE
#193 : fallback on static versions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ If you are behind a web proxy, use the `https_proxy` environment variable to con
 ```shell
 export https_proxy=http://localhost:3128
 ```
+Symphony Generator will automatically fetch the latest version of BDKs/WDK and use it to generate your project. In case the request fails, it will fallback on a default version.
 
 ## Known issues
 

--- a/generators/java/index.js
+++ b/generators/java/index.js
@@ -8,16 +8,15 @@ const COMMON_EXT_APP_TEMPLATES = '../../_common/circle-of-trust-ext-app'
 const BASE_JAVA = 'src/main/java';
 const BASE_RESOURCES = 'src/main/resources';
 
-const BDK_VERSION_DEFAULT = '2.3.0';
-const SPRING_VERSION_DEFAULT = '2.5.3'
+const BDK_VERSION_DEFAULT = '2.6.0';
+const SPRING_VERSION_DEFAULT = '2.6.8'
 
 // Make it configurable for faster test execution
 const KEY_PAIR_LENGTH = 'KEY_PAIR_LENGTH';
 
 const _getVersion = () => {
-  return axios.get('http://search.maven.org/solrsearch/select?q=g:org.finos.symphony.bdk')
-    .then(res => res.data)
-    .catch(err => console.log(err));
+  return axios.get('https://seasfrch.maven.org/solrsearch/select?q=g:org.finos.symphony.bdk')
+    .then(res => res.data);
 }
 
 module.exports = class extends Generator {
@@ -73,6 +72,9 @@ module.exports = class extends Generator {
       } else {
         this.answers.bdkBomVersion = response['response']['docs'][0]['latestVersion'];
       }
+    }).catch(err => {
+      console.log(`Failed to fetch latest Java BDK version from Maven Central, ${this.answers.bdkBomVersion} will be used.`);
+      console.log(`The request failed because of: {errno: ${err.errno}, code: ${err.code}}`);
     });
 
     try {

--- a/generators/java/index.js
+++ b/generators/java/index.js
@@ -15,7 +15,7 @@ const SPRING_VERSION_DEFAULT = '2.6.8'
 const KEY_PAIR_LENGTH = 'KEY_PAIR_LENGTH';
 
 const _getVersion = () => {
-  return axios.get('https://seasfrch.maven.org/solrsearch/select?q=g:org.finos.symphony.bdk')
+  return axios.get('https://search.maven.org/solrsearch/select?q=g:org.finos.symphony.bdk')
     .then(res => res.data);
 }
 

--- a/generators/python/index.js
+++ b/generators/python/index.js
@@ -4,7 +4,7 @@ const path = require('path');
 const axios = require("axios");
 
 const KEY_PAIR_LENGTH = 'KEY_PAIR_LENGTH';
-const BDK_VERSION_DEFAULT = '2.0.0';
+const BDK_VERSION_DEFAULT = '2.2.0';
 
 const COMMON_TEMPLATE_FOLDER = '../../_common'
 const COMMON_EXT_APP_TEMPLATES = COMMON_TEMPLATE_FOLDER + '/circle-of-trust-ext-app'
@@ -14,8 +14,7 @@ const PYTHON_FOLDER = 'src' // target folder containing python sources
 
 const _getVersion = () => {
   return axios.get('https://pypi.org/pypi/symphony-bdk-python/json')
-    .then(res =>  res.data)
-    .catch(err => {});
+    .then(res =>  res.data);
 }
 
 module.exports = class extends Generator {
@@ -31,6 +30,9 @@ module.exports = class extends Generator {
       } else {
         this.answers.bdkVersion = response['info']['version'];
       }
+    }).catch(err => {
+      console.log(`Failed to fetch latest Python BDK version from Pypi, ${this.answers.bdkVersion} will be used.`);
+      console.log(`The request failed because of: {errno: ${err.errno}, code: ${err.code}}`);
     });
 
     this._generateRsaKeys();

--- a/generators/workflow/index.js
+++ b/generators/workflow/index.js
@@ -8,12 +8,11 @@ const axios = require('axios');
 // Make it configurable for faster test execution
 const KEY_PAIR_LENGTH = 'KEY_PAIR_LENGTH';
 
-const WDK_VERSION_DEFAULT = '0.0.1-SNAPSHOT';
+const WDK_VERSION_DEFAULT = '1.0.0';
 
 const _getVersion = () => {
-  return axios.get('http://search.maven.org/solrsearch/select?q=g:org.finos.symphony.wdk')
-    .then(res => res.data)
-    .catch(err => console.log(err));
+  return axios.get('https://search.maven.org/solrsearch/select?q=g:org.finos.symphony.wdk')
+    .then(res => res.data);
 }
 
 module.exports = class extends Generator {
@@ -29,6 +28,9 @@ module.exports = class extends Generator {
       } else {
         this.templateSettings.wdkVersion = response['response']['docs'][0]['latestVersion'];
       }
+    }).catch(err => {
+      console.log(`Failed to fetch latest Symphony WDK version from Maven Central, ${this.templateSettings.wdkVersion} will be used.`);
+      console.log(`The request failed because of: {errno: ${err.errno}, code: ${err.code}}`);
     });
 
     try {

--- a/test/java-bdk.spec.js
+++ b/test/java-bdk.spec.js
@@ -23,7 +23,7 @@ describe('Java BDK error scenarios', () => {
   })
 
   it('Java BDK default version should be used when maven search query fails', () => {
-    axios.get.mockRejectedValueOnce();
+    axios.get.mockRejectedValueOnce({errno: -3008, code: 'ENOTFOUND'});
 
     return helpers.run(path.join(__dirname, '../generators/app'))
       .inTmpDir()
@@ -62,7 +62,7 @@ describe('Java BDK error scenarios', () => {
       })
   })
 
-  it('Java BDK default version should be used when maven search does not return latest version', () => {
+  /*it('Java BDK default version should be used when maven search does not return latest version', () => {
     axios.get.mockResolvedValue({"data": {"response": {"docs": []}}});
     
     return helpers.run(path.join(__dirname, '../generators/app'))
@@ -100,10 +100,10 @@ describe('Java BDK error scenarios', () => {
         let generatedPublicKey = fs.readFileSync('rsa/publickey.pem', 'utf-8')
         assertKeyPair(privateKey, generatedPublicKey)
       })
-  })
+  })*/
 })
 
-describe('Java BDK', () => {
+/*describe('Java BDK', () => {
   const currentDir = process.cwd()
 
   beforeAll(() => {
@@ -350,4 +350,4 @@ describe('Java BDK', () => {
         assertKeyPair(privateKey, generatedPublicKey)
       })
   })
-})
+})*/

--- a/test/java-bdk.spec.js
+++ b/test/java-bdk.spec.js
@@ -62,7 +62,7 @@ describe('Java BDK error scenarios', () => {
       })
   })
 
-  /*it('Java BDK default version should be used when maven search does not return latest version', () => {
+  it('Java BDK default version should be used when maven search does not return latest version', () => {
     axios.get.mockResolvedValue({"data": {"response": {"docs": []}}});
     
     return helpers.run(path.join(__dirname, '../generators/app'))
@@ -100,10 +100,10 @@ describe('Java BDK error scenarios', () => {
         let generatedPublicKey = fs.readFileSync('rsa/publickey.pem', 'utf-8')
         assertKeyPair(privateKey, generatedPublicKey)
       })
-  })*/
+  })
 })
 
-/*describe('Java BDK', () => {
+describe('Java BDK', () => {
   const currentDir = process.cwd()
 
   beforeAll(() => {
@@ -350,4 +350,4 @@ describe('Java BDK error scenarios', () => {
         assertKeyPair(privateKey, generatedPublicKey)
       })
   })
-})*/
+})

--- a/test/java-bdk.spec.js
+++ b/test/java-bdk.spec.js
@@ -14,6 +14,95 @@ const SMALL_KEY_PAIR_LENGTH = 512;
 const axios = require("axios");
 jest.mock('axios');
 
+describe('Java BDK error scenarios', () => {
+  const currentDir = process.cwd()
+
+  afterAll(() => {
+    process.chdir(currentDir);
+    jest.resetAllMocks();
+  })
+
+  it('Java BDK default version should be used when maven search query fails', () => {
+    axios.get.mockRejectedValueOnce();
+
+    return helpers.run(path.join(__dirname, '../generators/app'))
+      .inTmpDir()
+      .withLocalConfig({
+        KEY_PAIR_LENGTH: SMALL_KEY_PAIR_LENGTH
+      })
+      .withPrompts({
+        host: 'acme.symphony.com',
+        username: 'test-bot',
+        application: 'bot-app',
+        language: 'java',
+        build: 'Gradle',
+        framework: 'spring',
+        groupId: 'com.mycompany',
+        artifactId: 'bot-application',
+        basePackage: BASE_PACKAGE
+      }).then((dir) => {
+        assert.file([
+          'gradlew',
+          'gradlew.bat',
+          'build.gradle',
+          path.join(BASE_JAVA, PACKAGE_DIR, 'BotApplication.java'),
+          path.join(BASE_JAVA, PACKAGE_DIR, 'GifFormActivity.java'),
+          path.join(BASE_JAVA, PACKAGE_DIR, 'OnUserJoinedRoomListener.java'),
+          path.join(BASE_JAVA, PACKAGE_DIR, 'GifSlashHandler.java'),
+          'rsa/privatekey.pem',
+          'rsa/publickey.pem',
+          '.gitignore',
+          path.join(BASE_RESOURCE, 'templates/welcome.ftl'),
+          path.join(BASE_RESOURCE, 'templates/gif.ftl'),
+          path.join(BASE_RESOURCE, 'application.yaml')
+        ]);
+        let privateKey = fs.readFileSync('rsa/privatekey.pem', 'utf-8')
+        let generatedPublicKey = fs.readFileSync('rsa/publickey.pem', 'utf-8')
+        assertKeyPair(privateKey, generatedPublicKey)
+      })
+  })
+
+  it('Java BDK default version should be used when maven search does not return latest version', () => {
+    axios.get.mockResolvedValue({"data": {"response": {"docs": []}}});
+    
+    return helpers.run(path.join(__dirname, '../generators/app'))
+      .inTmpDir()
+      .withLocalConfig({
+        KEY_PAIR_LENGTH: SMALL_KEY_PAIR_LENGTH
+      })
+      .withPrompts({
+        host: 'acme.symphony.com',
+        username: 'test-bot',
+        application: 'bot-app',
+        language: 'java',
+        build: 'Gradle',
+        framework: 'spring',
+        groupId: 'com.mycompany',
+        artifactId: 'bot-application',
+        basePackage: BASE_PACKAGE
+      }).then((dir) => {
+        assert.file([
+          'gradlew',
+          'gradlew.bat',
+          'build.gradle',
+          path.join(BASE_JAVA, PACKAGE_DIR, 'BotApplication.java'),
+          path.join(BASE_JAVA, PACKAGE_DIR, 'GifFormActivity.java'),
+          path.join(BASE_JAVA, PACKAGE_DIR, 'OnUserJoinedRoomListener.java'),
+          path.join(BASE_JAVA, PACKAGE_DIR, 'GifSlashHandler.java'),
+          'rsa/privatekey.pem',
+          'rsa/publickey.pem',
+          '.gitignore',
+          path.join(BASE_RESOURCE, 'templates/welcome.ftl'),
+          path.join(BASE_RESOURCE, 'templates/gif.ftl'),
+          path.join(BASE_RESOURCE, 'application.yaml')
+        ]);
+        let privateKey = fs.readFileSync('rsa/privatekey.pem', 'utf-8')
+        let generatedPublicKey = fs.readFileSync('rsa/publickey.pem', 'utf-8')
+        assertKeyPair(privateKey, generatedPublicKey)
+      })
+  })
+})
+
 describe('Java BDK', () => {
   const currentDir = process.cwd()
 

--- a/test/python-bdk.spec.js
+++ b/test/python-bdk.spec.js
@@ -47,7 +47,7 @@ describe('Python BDK error scenarios', () => {
   })
 
   it('Python BDK default version should be used when maven search does not return latest version', () => {
-    axios.get.mockResolvedValue({"data": {"response": {"docs": []}}});
+    axios.get.mockResolvedValue(undefined);
 
     return helpers.run(path.join(__dirname, '../generators/app'))
     .inTmpDir()

--- a/test/python-bdk.spec.js
+++ b/test/python-bdk.spec.js
@@ -24,7 +24,7 @@ describe('Python BDK error scenarios', () => {
   })
 
   it('Python BDK default version should be used when maven search query fails', () => {
-    axios.get.mockRejectedValueOnce();
+    axios.get.mockRejectedValueOnce({errno: -3008, code: 'ENOTFOUND'});
 
     return helpers.run(path.join(__dirname, '../generators/app'))
     .inTmpDir()

--- a/test/python-bdk.spec.js
+++ b/test/python-bdk.spec.js
@@ -15,6 +15,61 @@ const SMALL_KEY_PAIR_LENGTH = 512;
 const axios = require("axios");
 jest.mock('axios');
 
+describe('Python BDK error scenarios', () => {
+  const currentDir = process.cwd()
+
+  afterAll(() => {
+    process.chdir(currentDir);
+    jest.resetAllMocks();
+  })
+
+  it('Python BDK default version should be used when maven search query fails', () => {
+    axios.get.mockRejectedValueOnce();
+
+    return helpers.run(path.join(__dirname, '../generators/app'))
+    .inTmpDir()
+    .withLocalConfig({
+      KEY_PAIR_LENGTH: SMALL_KEY_PAIR_LENGTH
+    })
+    .withPrompts({
+      host: 'acme.symphony.com',
+      username: 'test-bot',
+      application: 'bot-app',
+      language: 'python',
+      appId: 'app-id'
+    }).then((dir) => {
+      assertCommonFilesGenerated(dir);
+      assert.file([
+        path.join(BASE_PYTHON, 'activities.py'),
+        path.join(BASE_PYTHON, 'gif_activities.py'),
+        path.join(BASE_RESOURCE, 'gif.jinja2')]);
+    })
+  })
+
+  it('Python BDK default version should be used when maven search does not return latest version', () => {
+    axios.get.mockResolvedValue({"data": {"response": {"docs": []}}});
+
+    return helpers.run(path.join(__dirname, '../generators/app'))
+    .inTmpDir()
+    .withLocalConfig({
+      KEY_PAIR_LENGTH: SMALL_KEY_PAIR_LENGTH
+    })
+    .withPrompts({
+      host: 'acme.symphony.com',
+      username: 'test-bot',
+      application: 'bot-app',
+      language: 'python',
+      appId: 'app-id'
+    }).then((dir) => {
+      assertCommonFilesGenerated(dir);
+      assert.file([
+        path.join(BASE_PYTHON, 'activities.py'),
+        path.join(BASE_PYTHON, 'gif_activities.py'),
+        path.join(BASE_RESOURCE, 'gif.jinja2')]);
+    })
+  })
+})
+
 describe('Python BDK', () => {
   const currentDir = process.cwd()
 

--- a/test/workflow.spec.js
+++ b/test/workflow.spec.js
@@ -9,6 +9,64 @@ jest.mock('axios');
 
 const SMALL_KEY_PAIR_LENGTH = 512;
 
+describe('WDK error scenarios', () => {
+  axios.get.mockRejectedValueOnce();
+
+  it('WDK default version should be used when maven search query fails', () => {
+    return helpers.run(path.join(__dirname, '../generators/app'))
+      .inTmpDir()
+      .withLocalConfig({
+        KEY_PAIR_LENGTH: SMALL_KEY_PAIR_LENGTH
+      })
+      .withPrompts({
+        host: 'acme.symphony.com',
+        username: 'test-bot',
+        application: 'workflow-bot-app',
+      })
+      .then((dir) => {
+        assert.file([
+          'application.yaml',
+          'workflow-bot-app.jar',
+          'lib',
+          'workflows/ping.swadl.yaml',
+          'README.md',
+          'Dockerfile'
+        ]);
+        let privateKey = fs.readFileSync('rsa/privatekey.pem', 'utf-8')
+        let generatedPublicKey = fs.readFileSync('rsa/publickey.pem', 'utf-8')
+        assertKeyPair(privateKey, generatedPublicKey)
+      })
+  })
+
+  it('WDK default version should be used when maven search does not return latest version', () => {
+    axios.get.mockResolvedValue({"data": {"response": {"docs": []}}});
+
+    return helpers.run(path.join(__dirname, '../generators/app'))
+      .inTmpDir()
+      .withLocalConfig({
+        KEY_PAIR_LENGTH: SMALL_KEY_PAIR_LENGTH
+      })
+      .withPrompts({
+        host: 'acme.symphony.com',
+        username: 'test-bot',
+        application: 'workflow-bot-app',
+      })
+      .then((dir) => {
+        assert.file([
+          'application.yaml',
+          'workflow-bot-app.jar',
+          'lib',
+          'workflows/ping.swadl.yaml',
+          'README.md',
+          'Dockerfile'
+        ]);
+        let privateKey = fs.readFileSync('rsa/privatekey.pem', 'utf-8')
+        let generatedPublicKey = fs.readFileSync('rsa/publickey.pem', 'utf-8')
+        assertKeyPair(privateKey, generatedPublicKey)
+      })
+  })
+})
+
 describe('Workflow bot', () => {
   const currentDir = process.cwd()
 

--- a/test/workflow.spec.js
+++ b/test/workflow.spec.js
@@ -10,7 +10,7 @@ jest.mock('axios');
 const SMALL_KEY_PAIR_LENGTH = 512;
 
 describe('WDK error scenarios', () => {
-  axios.get.mockRejectedValueOnce();
+  axios.get.mockRejectedValueOnce({errno: -3008, code: 'ENOTFOUND'});
 
   it('WDK default version should be used when maven search query fails', () => {
     return helpers.run(path.join(__dirname, '../generators/app'))


### PR DESCRIPTION
### Description
Closes #193 
When generating a project, we fetch the latest versions of the BDK/WDK. In this PR, we catch the error when this request fails, and we use the default hardcoded version.
The default hardcoded version will be updated before every release of finos/Symphony generator.
Made use of https instead of http for the fetch request.

![fallback](https://user-images.githubusercontent.com/52406574/173394108-be788a8d-0c00-4b71-80a1-34d980a2f47b.png)


### Checklist
- [x] Referenced an issue in the PR title or description
- [x] Filled properly the description and dependencies, if any
- [x] Unit/Integration tests updated or added
- [] Javadoc added or updated
- [x] Updated the documentation in [docs folder](../docs)
