### PR TITLE
Improve the generated project build capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ export https_proxy=http://localhost:3128
 ```
 Symphony Generator will automatically fetch the latest version of BDKs/WDK and use it to generate your project. In case the request fails, it will fallback on a default version.
 
+In case of a Java bot application, once the project is generated, the generator will try to download the chosen package manager wrapper to build the project. If for any reason (e.g. network constraint) the build fails, the generator will then try to build the project again by using local package manager.
+
+_NOTE:_ The generation process will continue no matter what the build status is.  
+
 ## Known issues
 
 If you are using node 16.0.0 and encounter the following error when trying to run `yo @finos/symphony` or `yo @finos/symphony 2.0`:

--- a/generators/java/index.js
+++ b/generators/java/index.js
@@ -174,18 +174,41 @@ module.exports = class extends Generator {
    * Build Maven or Gradle project
    */
   install() {
-    let buildResult;
-
     if (this.answers.build === 'Maven') {
-      this.log('Running '.green.bold + './mvnw package'.white.bold + ' in your project'.green.bold);
-      buildResult = this.spawnCommandSync(path.join(this.destinationPath(), 'mvnw'), ['package']);
+      try {        
+        this.log('Running '.green.bold + './mvnw package'.white.bold + ' in your project'.green.bold);
+        this.spawnCommandSync(path.join(this.destinationPath(), 'mvnw'), ['package']);
+      } catch(e) {
+        this._localInstall();
+      }
     } else {
-      this.log('Running '.green.bold + './gradlew build'.white.bold + ' in your project'.green.bold);
-      buildResult = this.spawnCommandSync(path.join(this.destinationPath(), 'gradlew'), ['build']);
+      try {
+        this.log('Running '.green.bold + './gradlew build'.white.bold + ' in your project'.green.bold);
+        buildResult = this.spawnCommandSync(path.join(this.destinationPath(), 'gradlew'), ['build']);
+      } catch(e) {        
+        this._localInstall();
+      }
     }
+  }
 
-    if (buildResult.status !== 0) {
-      this.log.error(buildResult.stderr);
+  _localInstall() {    
+    let errorMessage = 'Failed to build the generated project.';  
+    if (this.answers.build === 'Maven') {
+      try {
+        this.log('Running '.green.bold + 'mvn package'.white.bold + ' in your project'.green.bold);
+        this.spawnCommandSync('mvn', ['package']);
+      } catch(e) {          
+        this.log(`${e}`.green.bold);
+        console.log(errorMessage);
+      }
+    } else {        
+      try {
+        this.log('Running '.green.bold + 'gradle build'.white.bold + ' in your project'.green.bold);
+        this.spawnCommandSync('gradle', ['build']);
+      } catch(e) {                   
+        this.log(`${e}`.green.bold);
+        console.log(errorMessage);
+      }
     }
   }
 


### PR DESCRIPTION
Before this commit, the generation process would stop in case the build
on the generated project fails. For instance, the package manager wrapper
cannot be downloaded due to network issue.

This commit improves the project build capability by tring to run
a the build again by using a local package manager in case there is an
issue when build fails using wrapper. In addition, no matter what the build
status is, the generation process will continue to the end.

### Description
Closes #199
