### PR TITLE
Update WDK default version to 1.2.0

### DIFF
--- a/generators/workflow/index.js
+++ b/generators/workflow/index.js
@@ -8,7 +8,7 @@ const axios = require('axios');
 // Make it configurable for faster test execution
 const KEY_PAIR_LENGTH = 'KEY_PAIR_LENGTH';
 
-const WDK_VERSION_DEFAULT = '1.0.0';
+const WDK_VERSION_DEFAULT = '1.2.0';
 
 const _getVersion = () => {
   return axios.get('https://search.maven.org/solrsearch/select?q=g:org.finos.symphony.wdk')


### PR DESCRIPTION
### Description
Now that WDK 1.2.0 is released, it should be the default one to be used in generator.