### PR TITLE
Fix Maven executable JAR and skip key generation for sandbox

### DIFF
--- a/generators/java/templates/pom.xml.ejs
+++ b/generators/java/templates/pom.xml.ejs
@@ -75,26 +75,30 @@
     </dependencies>
 
     <build>
-        <pluginManagement>
-            <plugins>
+        <plugins>
 <% if (framework == 'spring' || application == 'ext-app') { -%>
-                <plugin>
-                    <groupId>org.springframework.boot</groupId>
-                    <artifactId>spring-boot-maven-plugin</artifactId>
-                    <version><%= springBootVersion %></version>
-                </plugin>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version><%= springBootVersion %></version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
 <% } -%>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.1</version>
-                    <configuration>
-                        <source>1.8</source>
-                        <target>1.8</target>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </pluginManagement>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
-
 </project>

--- a/generators/python/index.js
+++ b/generators/python/index.js
@@ -18,7 +18,6 @@ const _getVersion = () => {
 }
 
 module.exports = class extends Generator {
-
   async writing() {
     this.answers = this.options;
     this.answers.bdkVersion = BDK_VERSION_DEFAULT;
@@ -52,10 +51,12 @@ module.exports = class extends Generator {
   end() {
     if (this.pair) {
       this.log('\nYou can now update the service account '.cyan +
-        `${this.answers.username}`.white.bold +
-        ` with the following public key on https://${this.answers.host}/admin-console : `.cyan);
-
+        `${this.answers.username}`.white.bold + ` with the following public key: `.cyan);
       this.log('\n' + this.pair.public);
+      this.log(`Please submit these details to your pod administrator.`.yellow);
+      this.log(`If you are a pod administrator, visit https://${this.answers.host}/admin-console\n`.yellow);
+    } else {
+      this.log('\nYou can now place the private key you received in the '.yellow + 'rsa'.white + ' directory\n'.yellow);
     }
 
     this.log(`Your Python project has been successfully generated !`.cyan.bold);
@@ -70,16 +71,17 @@ module.exports = class extends Generator {
   }
 
   _generateRsaKeys() {
-    try {
-      let rsa_folder = 'rsa';
-      this.log('Generating RSA keys...'.green.bold);
-      this.pair = keyPair(this.config.get(KEY_PAIR_LENGTH) || 4096);
-      this.fs.write(this.destinationPath(rsa_folder + '/publickey.pem'), this.pair.public, err => this.log.error(err));
-      this.fs.write(this.destinationPath(rsa_folder + '/privatekey.pem'), this.pair.private, err => this.log.error(err));
-      this.answers.privateKeyPath = rsa_folder + '/privatekey.pem';
-    } catch (e) {
-      this.log.error(`Oups, something went wrong when generating RSA key pair`, e);
+    if (this.answers.host !== 'develop2.symphony.com') {
+      try {
+        this.log('Generating RSA keys...'.green.bold);
+        this.pair = keyPair(this.config.get(KEY_PAIR_LENGTH) || 4096);
+        this.fs.write(this.destinationPath('rsa/publickey.pem'), this.pair.public, err => this.log.error(err));
+        this.fs.write(this.destinationPath('rsa/privatekey.pem'), this.pair.private, err => this.log.error(err));
+      } catch (e) {
+        this.log.error(`Oups, something went wrong when generating RSA key pair`, e);
+      }
     }
+    this.answers.privateKeyPath = 'rsa/privatekey.pem';
   }
 
   _generateCommonFiles() {

--- a/test/java-bdk.spec.js
+++ b/test/java-bdk.spec.js
@@ -64,7 +64,7 @@ describe('Java BDK error scenarios', () => {
 
   it('Java BDK default version should be used when maven search does not return latest version', () => {
     axios.get.mockResolvedValue({"data": {"response": {"docs": []}}});
-    
+
     return helpers.run(path.join(__dirname, '../generators/app'))
       .inTmpDir()
       .withLocalConfig({
@@ -187,6 +187,37 @@ describe('Java BDK', () => {
         let privateKey = fs.readFileSync('rsa/privatekey.pem', 'utf-8')
         let generatedPublicKey = fs.readFileSync('rsa/publickey.pem', 'utf-8')
         assertKeyPair(privateKey, generatedPublicKey)
+      })
+  })
+
+  it('Generate 2.0 java gradle sandbox', () => {
+    return helpers.run(path.join(__dirname, '../generators/app'))
+      .inTmpDir()
+      .withLocalConfig({
+        KEY_PAIR_LENGTH: SMALL_KEY_PAIR_LENGTH
+      })
+      .withPrompts({
+        host: 'develop2.symphony.com',
+        username: 'test-bot',
+        application: 'bot-app',
+        language: 'java',
+        build: 'Gradle',
+        framework: 'java',
+        groupId: 'com.mycompany',
+        artifactId: 'bot-application',
+        basePackage: BASE_PACKAGE
+      })
+      .then((dir) => {
+        assert.file([
+          'gradlew',
+          'gradlew.bat',
+          'build.gradle',
+          path.join(BASE_JAVA, PACKAGE_DIR, 'BotApplication.java'),
+          '.gitignore',
+          path.join(BASE_RESOURCE, 'templates/welcome.ftl'),
+          path.join(BASE_RESOURCE, 'templates/gif.ftl'),
+          path.join(BASE_RESOURCE, 'config.yaml')
+        ]);
       })
   })
 


### PR DESCRIPTION
### Description
Closes #215 and #216

* Fix maven executable JAR bug
* Skip the generation of key pair if the host supplied uses `develop2.symphony.com`
* Provide an appropriate end message for the developer to use their supplied key instead
* For non-sandbox hosts, clarify that the end message is meant for pod administrators to action
